### PR TITLE
I ran this code and getting this error. Please fix it.

pnpm dev

> template-nexts-page-tailwind@0.1.0 dev /Users/anusheel/projects/lightapps-front
> ...

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,23 +7,23 @@ export default function Header() {
         <ul className="flex space-x-4">
           <li>
             <Link href="/">
-              <a>Home</a>
+              <button>Home</button>
             </Link>
           </li>
           <li>
             <Link href="/showcase">
-              <a>Showcase</a>
+              <button>Showcase</button>
             </Link>
           </li>
           <li>
             <Link href="/contact">
-              <a>Contact Us</a>
+              <button>Contact Us</button>
             </Link>
           </li>
         </ul>
       </nav>
       <Link href="/">
-        <a className="text-2xl font-bold">Lightapps</a>
+        <button className="text-2xl font-bold">Lightapps</button>
       </Link>
     </header>
   );


### PR DESCRIPTION
I ran this code and getting this error. Please fix it.

pnpm dev

> template-nexts-page-tailwind@0.1.0 dev /Users/anusheel/projects/lightapps-front
> next dev


 ⚠ Port 3000 is in use, trying 3001 instead.

  ▲ Next.js 13.5.4
  - Local:        http://localhost:3001

 ✓ Ready in 5.7s
 ✓ Compiled / in 2.7s (256 modules)
 ✓ Compiled in 147ms (256 modules)
Error: Invalid <Link> with <a> child. Please remove <a> or use <Link legacyBehavior>.
Learn more: https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor
    at LinkComponent (webpack-internal:///./node_modules/.pnpm/next@13.5.4_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/client/link.js:267:23)
    at renderWithHooks (/Users/anusheel/projects/lightapps-front/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5658:16)
    at renderForwardRef (/Users/anusheel/projects/lightapps-front/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5842:18)
    at renderElement (/Users/anusheel/projects/lightapps-front/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6005:11)
    at renderNodeDestructiveImpl (/Users/anusheel/projects/lightapps-front/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6104:11)
    at renderNodeDestructive (/Users/anusheel/projects/lightapps-front/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6076:14)
    at renderNode (/Users/anusheel/projects/lightapps-front/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6259:12)
    at renderHostElement (/Users/anusheel/projects/lightapps-front/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5642:3)
    at renderElement (/Users/anusheel/projects/lightapps-front/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom-server.browser.development.js:5952:5)
    at renderNodeDestructiveImpl (/Users/anusheel/projects/lightapps-front/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6104:11)
    at renderNodeDestructive (/Users/anusheel/projects/lightapps-front/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6076:14)
    at renderNode (/Users/anusheel/projects/lightapps-front/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6259:12)
    at renderChildrenArray (/Users/anusheel/projects/lightapps-front/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6211:7)
    at renderNodeDestructiveImpl (/Users/anusheel/projects/lightapps-front/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6141:7)
    at renderNodeDestructive (/Users/anusheel/projects/lightapps-front/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom-server.browser.development.js:6076:14)
 ⨯ node_modules/.pnpm/next@13.5.4_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/client/link.js (272:22) @ LinkComponent
 ⨯ Error: Invalid <Link> with <a> child. Please remove <a> or use <Link legacyBehavior>.
Learn more: https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor